### PR TITLE
Update Raffle application.conf

### DIFF
--- a/samples/raffle/src/main/resources/application.conf
+++ b/samples/raffle/src/main/resources/application.conf
@@ -56,7 +56,6 @@ akka {
 
         event-adapter-bindings = {
           "raffle.domain.model.RaffleEvent" = domain-tagger
-          "io.funcqrs.akka.LastProcessedEventOffsetLong" = domain-tagger
         }
       }
 


### PR DESCRIPTION
prevents runtime error when starting MainAkka, possibly Renato had richer functionality in mind when introducing that domain-tagger and never completed it?